### PR TITLE
Mark provider as deprecated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 # Equinix Metal provider
 
-**PLEASE NOTE:** *This provider supercedes the Pulumi Packet provider. There is no direct migration between providers. To perform a migration,
-please use the pulumi import command*
+**PLEASE NOTE:** *This provider has been DEPRECATED in favor of https://github.com/equinix/pulumi-equinix. Please use Equinix' official Pulumi provider going forward.*
 
 The Equinix Metal resource provider for Pulumi lets you use [Equinix Metal](https://metal.equinix.com/) resources in your cloud programs.  To use
 this package, please [install the Pulumi CLI first](https://pulumi.io/).


### PR DESCRIPTION
Part of #136.

Note this will not pass CI due to dirty Python worktree, as I did not re-generate the provider.

